### PR TITLE
Replace poetry install method

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,10 +9,8 @@ ARG NODE_VERSION="none"
 RUN if [ "${NODE_VERSION}" != "none" ]; then su vscode -c "umask 0002 && . /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
 
 # Install poetry
-RUN pip install poetry
-
-# Configure poetry env
-RUN su vscode -c "poetry config virtualenvs.in-project true"
+RUN curl -sSL "https://install.python-poetry.org" | python && \
+    su vscode -c "sudo /root/.local/bin/poetry config virtualenvs.in-project true"
 
 # Install jshint
 RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g jshint" 2>&1


### PR DESCRIPTION
Recomended way not works. Replaced to pip-method, as in Docker we have only one python version (because of this we don't need multi-version support from poetry) and `pip check` works correctly. 